### PR TITLE
Indicate that phpunit 5.x can be used with php7

### DIFF
--- a/plugin-unit-tests.md
+++ b/plugin-unit-tests.md
@@ -14,7 +14,7 @@ We're going to assume that you already have a plugin called `my-plugin`.
 
 So, let's get started:
 
-1) [Install PHPUnit](https://github.com/sebastianbergmann/phpunit#installation) (4.8.x required, 5.x not supported).
+1) [Install PHPUnit](https://github.com/sebastianbergmann/phpunit#installation) (5.x is only supported when running php7, phpunit 4.8 is required when running php5).
 
 2) Generate the plugin test files:
 


### PR DESCRIPTION
Since [PR#3463](https://github.com/wp-cli/wp-cli/pull/3463), it's possible to use phpunit 5.x when running php7. This should be clarified in the docs.